### PR TITLE
(4-2)給料の表記がカンマ区切りになるよう変更しました

### DIFF
--- a/src/main/resources/templates/employee/detail.html
+++ b/src/main/resources/templates/employee/detail.html
@@ -168,7 +168,7 @@
                   <tr>
                     <th nowrap>給料</th>
                     <td>
-                      <span th:utext="${employee.salary + '円'}">400000円</span>
+                      <span th:utext="${#numbers.formatInteger(employee.salary,1,'COMMA') + '円'}">400000円</span>
                     </td>
                   </tr>
                   <tr>


### PR DESCRIPTION
従業員詳細画面にて給料の表記がカンマ区切りになるよう変更しましたので確認をお願いします。

何かあればコメントを頂ければと思います。
問題がなければマージをお願いします。